### PR TITLE
aya-bpf-macros: return proper error value from LSM probes

### DIFF
--- a/bpf/aya-bpf-macros/src/expand.rs
+++ b/bpf/aya-bpf-macros/src/expand.rs
@@ -401,9 +401,8 @@ impl Lsm {
         Ok(quote! {
             #[no_mangle]
             #[link_section = #section_name]
-            fn #fn_name(ctx: *mut ::core::ffi::c_void) -> u32 {
-                let _ = #fn_name(::aya_bpf::programs::LsmContext::new(ctx));
-                return 0;
+            fn #fn_name(ctx: *mut ::core::ffi::c_void) -> i32 {
+                return #fn_name(::aya_bpf::programs::LsmContext::new(ctx));
 
                 #item
             }


### PR DESCRIPTION
LSM probes need to be able to return a negative integer in case we want to deny the access. This fixes the `#[lsm]` macro by making the generated function return the correct `i32` value.